### PR TITLE
refactored to use batch rendering

### DIFF
--- a/community/tilemap/main.go
+++ b/community/tilemap/main.go
@@ -17,7 +17,9 @@ import (
 var clearColor = colornames.Skyblue
 
 func gameloop(win *pixelgl.Window, tilemap *tmx.Map) {
-	batches := make(map[string]*pixel.Batch)
+	batches := make([]*pixel.Batch, 0)
+	batchIndices := make(map[string]int)
+	batchCounter := 0
 
 	// Load the sprites
 	sprites := make(map[string]*pixel.Sprite)
@@ -25,7 +27,9 @@ func gameloop(win *pixelgl.Window, tilemap *tmx.Map) {
 		if _, alreadyLoaded := sprites[tileset.Image.Source]; !alreadyLoaded {
 			sprite, pictureData := loadSprite(tileset.Image.Source)
 			sprites[tileset.Image.Source] = sprite
-			batches[tileset.Image.Source] = pixel.NewBatch(&pixel.TrianglesData{}, pictureData)
+			batches = append(batches, pixel.NewBatch(&pixel.TrianglesData{}, pictureData))
+			batchIndices[tileset.Image.Source] = batchCounter
+			batchCounter++
 		}
 	}
 
@@ -88,7 +92,7 @@ func gameloop(win *pixelgl.Window, tilemap *tmx.Map) {
 				sprite := sprites[ts.Image.Source]
 				sprite.Set(sprite.Picture(), pixel.R(iX, iY, fX, fY))
 				pos := gamePos.ScaledXY(pixel.V(float64(ts.TileWidth), float64(ts.TileHeight)))
-				sprite.Draw(batches[ts.Image.Source], pixel.IM.Moved(pos))
+				sprite.Draw(batches[batchIndices[ts.Image.Source]], pixel.IM.Moved(pos))
 			}
 		}
 

--- a/community/tilemap/main.go
+++ b/community/tilemap/main.go
@@ -61,6 +61,10 @@ func gameloop(win *pixelgl.Window, tilemap *tmx.Map) {
 		win.Clear(clearColor)
 
 		// Draw tiles
+		for _, batch := range batches {
+			batch.Clear()
+		}
+
 		for _, layer := range tilemap.Layers {
 			for tileIndex, tile := range layer.DecodedTiles {
 				ts := layer.Tileset


### PR DESCRIPTION
Hi @faiface I caught your last comment on my last PR about using batch rendering in this example instead of drawing to the window directly! I just finished reading the wiki today so I went ahead and made the batch tweak. Thanks for allowing me to contribute here--I've learned a lot already about Pixel and have to say I'm having a lot of fun with it!

So quick note btw, I used a `map[string]*pixel.Batch` where the string key is actually the tileset's image source path. I did this because even though there is only one image used in this example tilemap, the TMX file supports multiple images and could therefore require multiple `*pixel.Batch` instances; using a map prevents duplicate batches (and sprites) from being created when they use the same image. I learned that technique when working with SDL2 a long time ago :) 